### PR TITLE
infectious agent survival in environment

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision.owl/" uri="decision-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/efo_import.owl" uri="imports/efo_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/gazetteer_import.owl" uri="imports/gazeteer_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/general_ontofox.owl" uri="imports/general_ontofox.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/hp_import.owl" uri="imports/hp_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/ncit_import.owl" uri="imports/ncit_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/obi_import.owl" uri="imports/obi_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/pato_import.owl" uri="imports/pato_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision.owl/" uri="decision-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/efo_import.owl" uri="imports/efo_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/gazetteer_import.owl" uri="imports/gazeteer_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/general_ontofox.owl" uri="imports/general_ontofox.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/hp_import.owl" uri="imports/hp_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/ncit_import.owl" uri="imports/ncit_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/obi_import.owl" uri="imports/obi_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592947988147" name="http://purl.obolibrary.org/obo/decision/imports/pato_import.owl" uri="imports/pato_import.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision.owl/" uri="decision-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/efo_import.owl" uri="imports/efo_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/gazetteer_import.owl" uri="imports/gazeteer_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/general_ontofox.owl" uri="imports/general_ontofox.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/hp_import.owl" uri="imports/hp_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/ncit_import.owl" uri="imports/ncit_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/obi_import.owl" uri="imports/obi_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1592251969236" name="http://purl.obolibrary.org/obo/decision/imports/pato_import.owl" uri="imports/pato_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision.owl/" uri="decision-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/efo_import.owl" uri="imports/efo_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/gazetteer_import.owl" uri="imports/gazeteer_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/general_ontofox.owl" uri="imports/general_ontofox.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/hp_import.owl" uri="imports/hp_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/ncit_import.owl" uri="imports/ncit_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/obi_import.owl" uri="imports/obi_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1592863500958" name="http://purl.obolibrary.org/obo/decision/imports/pato_import.owl" uri="imports/pato_import.owl"/>
     </group>
 </catalog>

--- a/src/ontology/decision-edit.owl
+++ b/src/ontology/decision-edit.owl
@@ -1330,6 +1330,51 @@ ISSUE:  infectious disease identification in a CASE is not &quot;outbreak infect
     
 
 
+    <!-- http://purl.obolibrary.org/obo/DECISION_0000077 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000077">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/TRANS_0000000"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000066"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000181"/>
+                                    <owl:Class>
+                                        <owl:unionOf rdf:parseType="Collection">
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000073"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000063"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002350"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCIT_C17153"/>
+                                            </owl:Restriction>
+                                        </owl:unionOf>
+                                    </owl:Class>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000073"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000088"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/TRANS_0000000"/>
+        <obo:IAO_0000112 xml:lang="en">&quot;What is the evidence for recommending face masks in risk groups 
+ (by occupation or pre-existing health conditions)&quot;</obo:IAO_0000112>
+        <rdfs:comment xml:lang="en">change &apos;medical specialty role&apos; to more generic &apos;professional role&apos; once &apos;professional role&apos; is imported</rdfs:comment>
+        <rdfs:label xml:lang="en">transmission process by population and PPE usage</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/DECISION_0000078 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000078">
@@ -1554,6 +1599,37 @@ ISSUE:  infectious disease identification in a CASE is not &quot;outbreak infect
     
 
 
+    <!-- http://purl.obolibrary.org/obo/DECISION_0000096 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000096">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.ebi.ac.uk/efo/EFO_0000714"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000925"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://www.ebi.ac.uk/efo/EFO_0000714"/>
+        <obo:IAO_0000112 xml:lang="en">What is the survival time of SARS-COV-2 as an airborne aerosol?</obo:IAO_0000112>
+        <rdfs:label xml:lang="en">infectious agent survival time in environment</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/DECISION_0000100 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000100">
@@ -1574,6 +1650,16 @@ ISSUE:  infectious disease identification in a CASE is not &quot;outbreak infect
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000101">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000010"/>
         <rdfs:label xml:lang="en">laboratory testing infectious disease identification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/DECISION_0000102 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000102">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_76311fd5_0c09_4ef0_aeb9_65375a3b841c2697049"/>
+        <obo:IAO_0000112 xml:lang="en">Coronavirus genomic RNA packaging</obo:IAO_0000112>
+        <rdfs:label xml:lang="en">viral genome RNA packaging</rdfs:label>
     </owl:Class>
     
 
@@ -3506,16 +3592,6 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     
 
 
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_4f1fccdf_f7f5_4865_86d1_a3cec6003b852697049 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4f1fccdf_f7f5_4865_86d1_a3cec6003b852697049">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_76311fd5_0c09_4ef0_aeb9_65375a3b841c2697049"/>
-        <obo:IAO_0000112 xml:lang="en">Coronavirus genomic RNA packaging</obo:IAO_0000112>
-        <rdfs:label xml:lang="en">viral genome RNA packaging</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_565995 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_565995">
@@ -4008,82 +4084,6 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C93874">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
     </rdf:Description>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_067d925e_a7a1_475f_b6a6_adfe20d159810002092 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/RO_067d925e_a7a1_475f_b6a6_adfe20d159810002092">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/TRANS_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000066"/>
-                        <owl:someValuesFrom>
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000181"/>
-                                    <owl:Class>
-                                        <owl:unionOf rdf:parseType="Collection">
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000073"/>
-                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000063"/>
-                                            </owl:Restriction>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002350"/>
-                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCIT_C17153"/>
-                                            </owl:Restriction>
-                                        </owl:unionOf>
-                                    </owl:Class>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                        </owl:someValuesFrom>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000073"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000088"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/TRANS_0000000"/>
-        <obo:IAO_0000112 xml:lang="en">&quot;What is the evidence for recommending face masks in risk groups 
- (by occupation or pre-existing health conditions)&quot;</obo:IAO_0000112>
-        <rdfs:comment xml:lang="en">change &apos;medical specialty role&apos; to more generic &apos;professional role&apos; once &apos;professional role&apos; is imported</rdfs:comment>
-        <rdfs:label xml:lang="en">transmission process by population and PPE usage</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_af52161a_92a4_4f37_9860_b6c6ecb1271d0002092 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/RO_af52161a_92a4_4f37_9860_b6c6ecb1271d0002092">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://www.ebi.ac.uk/efo/EFO_0000714"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
-                        <owl:someValuesFrom>
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000925"/>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                        </owl:someValuesFrom>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://www.ebi.ac.uk/efo/EFO_0000714"/>
-        <obo:IAO_0000112 xml:lang="en">What is the survival time of SARS-COV-2 as an airborne aerosol?</obo:IAO_0000112>
-        <rdfs:label xml:lang="en">infectious agent survival time in environment</rdfs:label>
-    </owl:Class>
     
 
 

--- a/src/ontology/decision-edit.owl
+++ b/src/ontology/decision-edit.owl
@@ -823,6 +823,7 @@ ISSUE:  infectious disease identification in a CASE is not &quot;outbreak infect
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000031">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000003"/>
+        <obo:IAO_0000112 xml:lang="en">HF nasal cannulation</obo:IAO_0000112>
         <obo:IAO_0000112>Is there evidence that the use of nasal high flow systems 40-60 litres with up to 60% oxygen is beneficial, harmful or increases risk of transmission of COVID- 19 (work in progress)?</obo:IAO_0000112>
         <obo:IAO_0000118 xml:lang="en">Is the outcome different between treated cases and untreated cases?</obo:IAO_0000118>
         <rdfs:label xml:lang="en">6. treatment regimen efficacy metric</rdfs:label>
@@ -1154,6 +1155,7 @@ ISSUE:  infectious disease identification in a CASE is not &quot;outbreak infect
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000063">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000003"/>
+        <obo:IAO_0000112 xml:lang="en">Does overweight/obesity increase the risk of severe disease or death?</obo:IAO_0000112>
         <obo:IAO_0000118 xml:lang="en">What are the risk factors of progression to poor outcome?</obo:IAO_0000118>
         <rdfs:label xml:lang="en">1.2 [infectious disease] risk factor</rdfs:label>
     </owl:Class>
@@ -1238,22 +1240,13 @@ ISSUE:  infectious disease identification in a CASE is not &quot;outbreak infect
                     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/DECISION_0000072"/>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000071"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
         <obo:IAO_0000112 xml:lang="en">What are the main transmission parameters of [SARS-COV-2] ?</obo:IAO_0000112>
         <rdfs:label xml:lang="en">transmission process in humans of [SARS-COV-2]</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/DECISION_0000071 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/DECISION_0000071">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
-        <rdfs:label xml:lang="en">human corona virus</rdfs:label>
     </owl:Class>
     
 
@@ -3395,10 +3388,18 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_11118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11118">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_11137 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11137">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3406,7 +3407,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_1335626 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1335626">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3450,7 +3451,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_2697049 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2697049">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3458,7 +3459,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_277944 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_277944">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3466,7 +3467,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_290028 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_290028">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3474,7 +3475,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_308726 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308726">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3482,7 +3483,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_31631 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31631">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3500,7 +3501,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_384335 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384335">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -3527,7 +3528,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_694009 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_694009">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
     </rdf:Description>
     
 
@@ -4007,6 +4008,51 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C93874">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
     </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_067d925e_a7a1_475f_b6a6_adfe20d159810002092 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/RO_067d925e_a7a1_475f_b6a6_adfe20d159810002092">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/TRANS_0000000"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000066"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000181"/>
+                                    <owl:Class>
+                                        <owl:unionOf rdf:parseType="Collection">
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000073"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000063"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002350"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCIT_C17153"/>
+                                            </owl:Restriction>
+                                        </owl:unionOf>
+                                    </owl:Class>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000073"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DECISION_0000088"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/TRANS_0000000"/>
+        <obo:IAO_0000112 xml:lang="en">&quot;What is the evidence for recommending face masks in risk groups 
+ (by occupation or pre-existing health conditions)&quot;</obo:IAO_0000112>
+        <rdfs:comment xml:lang="en">change &apos;medical specialty role&apos; to more generic &apos;professional role&apos; once &apos;professional role&apos; is imported</rdfs:comment>
+        <rdfs:label xml:lang="en">transmission process by population and PPE usage</rdfs:label>
+    </owl:Class>
     
 
 

--- a/src/ontology/decision-edit.owl
+++ b/src/ontology/decision-edit.owl
@@ -1682,9 +1682,41 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     
 
 
+    <!-- http://purl.obolibrary.org/obo/ENVO_00002008 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_00002008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00010483"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00010483 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_00010483">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00010505 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_00010505">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00010483"/>
+    </rdf:Description>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/ENVO_01000203 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000203"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000831 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_01000831">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00010483"/>
+    </rdf:Description>
     
 
 
@@ -3539,6 +3571,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_c36fbe8f_2442_40ad_8884_135b9818cb462697049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C17930"/>
         <obo:IAO_0000112 xml:lang="en">COVID-19, cytokines and immunosuppression: what can we learn from severe acute respiratory syndrome?</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">Coronavirus infections and immune responses</obo:IAO_0000112>
         <rdfs:label xml:lang="en">immune response to viral infection</rdfs:label>
     </owl:Class>
     
@@ -3731,7 +3764,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <obo:IAO_0000112 xml:lang="en">Coronavirus infections and immune responses</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en"></obo:IAO_0000112>
     </rdf:Description>
     
 
@@ -4002,6 +4035,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://www.ebi.ac.uk/efo/EFO_0000714"/>
+        <obo:IAO_0000112 xml:lang="en">What is the survival time of SARS-COV-2 as an airborne aerosol?</obo:IAO_0000112>
         <rdfs:label xml:lang="en">infectious agent survival time in environment</rdfs:label>
     </owl:Class>
     

--- a/src/ontology/decision-edit.owl
+++ b/src/ontology/decision-edit.owl
@@ -3363,6 +3363,22 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_11137 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11137">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1335626 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1335626">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_186536 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186536">
@@ -3407,6 +3423,38 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_277944 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_277944">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_290028 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_290028">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_308726 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308726">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_31631 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31631">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_31884076_36aa_4eae_85c3_66cb5b2e59bf2697049 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31884076_36aa_4eae_85c3_66cb5b2e59bf2697049">
@@ -3414,6 +3462,14 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
         <obo:IAO_0000112 xml:lang="en">Rapidly managing pneumonia in older people during a pandemic</obo:IAO_0000112>
         <rdfs:label xml:lang="en">infectious disease treatment for population by age during outbreak</rdfs:label>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384335 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384335">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
     
 
 
@@ -3433,6 +3489,14 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186536"/>
         <rdfs:label xml:lang="en">Bundibugyo ebolavirus</rdfs:label>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_694009 -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_694009">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+    </rdf:Description>
     
 
 
@@ -3474,6 +3538,7 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_c36fbe8f_2442_40ad_8884_135b9818cb462697049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C17930"/>
+        <obo:IAO_0000112 xml:lang="en">COVID-19, cytokines and immunosuppression: what can we learn from severe acute respiratory syndrome?</obo:IAO_0000112>
         <rdfs:label xml:lang="en">immune response to viral infection</rdfs:label>
     </owl:Class>
     
@@ -3909,6 +3974,36 @@ BUT: diseases have phases - through latent/incubation/contagious/ initial / subs
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C93874">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
     </rdf:Description>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_af52161a_92a4_4f37_9860_b6c6ecb1271d0002092 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/RO_af52161a_92a4_4f37_9860_b6c6ecb1271d0002092">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.ebi.ac.uk/efo/EFO_0000714"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000925"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://www.ebi.ac.uk/efo/EFO_0000714"/>
+        <rdfs:label xml:lang="en">infectious agent survival time in environment</rdfs:label>
+    </owl:Class>
     
 
 

--- a/src/ontology/imports/general_ontofox.owl
+++ b/src/ontology/imports/general_ontofox.owl
@@ -24,9 +24,6 @@
         <obo:IAO_0000115 xml:lang="en">An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)</obo:IAO_0000115>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
-        <rdfs:label xml:lang="en">imported from</rdfs:label>
-    </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">textual definition</rdfs:label>
@@ -38,6 +35,9 @@
         <obo:IAO_0000115>A property representing the English language definitions of what NCI means by the concept. They may also include information about the definition&#39;s source and attribution in a form that can easily be interpreted by software.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official OBI definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
         <rdfs:label>label</rdfs:label>
@@ -54,6 +54,26 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#subClassOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#subClassOf">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:ObjectProperty>
     
 
 
@@ -127,6 +147,17 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/BFO_0000017 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000017">
+        <rdfs:label xml:lang="en">realizable entity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+        <obo:IAO_0000115 xml:lang="en">A specifically dependent continuant  that inheres in continuant  entities and are not exhibited in full at every time in which it inheres in an entity or group of entities. The exhibition or actualization of a realizable entity is a particular manifestation, functioning or process that occurs under certain circumstances.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/BFO_0000019 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019">
@@ -146,6 +177,17 @@
         <obo:IAO_0000115 xml:lang="en">b is a relational specifically dependent continuant = Def. b is a specifically dependent continuant and there are n &amp;gt; 1 independent continuants c1, … cn which are not spatial regions are such that for all 1  i &amp;lt; j  n, ci  and cj share no common parts, are such that for each 1  i  n, b s-depends_on ci at every time t during the course of b’s existence (axiom label in BFO2 Reference: [131-004])</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">b is a specifically dependent continuant = Def. b is a continuant &amp; there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000023 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023">
+        <rdfs:label xml:lang="en">role</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
+        <obo:IAO_0000115 xml:lang="en">A realizable entity  the manifestation of which brings about some result or end that is not essential to a continuant  in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant  in some kinds of natural, social or institutional contexts.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
     </owl:Class>
     
@@ -172,12 +214,118 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/ENVO_00002008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00002008">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dust</rdfs:label>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Minute solid particles with diameters less than 500 micrometers. Occurs in and may be deposited from, the atmosphere.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00010483 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00010483">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">environmental material</rdfs:label>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A portion of environmental material is a fiat object part which forms the medium or part of the medium of an environmental system.</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A portion of environmental material is a fiat object which forms the medium or part of the medium of an environmental system.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00010505 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00010505">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aerosol</rdfs:label>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Airborne solid particles (also called dust or particulate matter (PM)) or liquid droplets.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/ENVO_01000203 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000203">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">environmental condition</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001018"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An environmental condition is a range of a determinate quality or combination of qualities that are present in an environmental system.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000405 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000405">
+        <rdfs:label xml:lang="en">respirable suspended particulate matter</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01001089"/>
+        <obo:IAO_0000115>A portion of respirable suspended particulate matter is a form of particulate matter composed primarily of solid particles each with a diameter of 10 micrometers or less.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000415 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000415">
+        <rdfs:label xml:lang="en">fine respirable suspended particulate matter</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000405"/>
+        <obo:IAO_0000115>A portion of fine respirable suspended particulate matter is a form of particulate matter composed primarily of solid particles each with a diameter of 2.5 micrometers or less.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000416 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000416">
+        <rdfs:label xml:lang="en">ultrafine respirable suspended particulate matter</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000415"/>
+        <obo:IAO_0000115>A portion of fine respirable suspended particulate matter is a form of particulate matter composed primarily of solid particles each with a diameter of  100 nanometers or less.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000831 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000831">
+        <rdfs:label xml:lang="en">droplet</rdfs:label>
+        <obo:IAO_0000115>A droplet is a small column of liquid, bounded completely or almost completely by free surfaces which maintains its shape due to the surface tension of the liquid.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000838 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000838">
+        <rdfs:label xml:lang="en">smoke</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00010505"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000842 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000842">
+        <rdfs:label xml:lang="en">smog</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000844"/>
+        <obo:IAO_0000115>A fog which is intermixed with smoke or other combustion products and their derivatives.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01000844 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000844">
+        <rdfs:label xml:lang="en">fog</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01001088"/>
+        <obo:IAO_0000115>A visible mass of cloud water droplets or ice crystals suspended in the air at or near a planetary surface.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
     </owl:Class>
     
@@ -212,6 +360,105 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000203"/>
         <obo:IAO_0000115>A condition which inheres in an environmental system by virtue of that system undergoing variation in its composition, the distribution of the qualities its components bear, and/or in the processes which occur within it and which it participates in.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01001088 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01001088">
+        <rdfs:label xml:lang="en">aerosolised liquids</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00010505"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An aerosol which has non-gaseous parts that are primarily composed of liquid droplets.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01001089 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01001089">
+        <rdfs:label xml:lang="en">aerosolised solids</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00010505"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An aerosol which has non-gaseous parts that are primarily composed of solid particles.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01001258 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01001258">
+        <rdfs:label xml:lang="en">vog</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000844"/>
+        <obo:IAO_0000115>A fog which is composed of liquid aerosols and gases derived from volcanic gas emissions (primarily sulfur oxides), formed when sulfur-bearing gases react with sunlight, oxygen, and moisture in an atmosphere.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01001402 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01001402">
+        <rdfs:label xml:lang="en">haze</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01001089"/>
+        <obo:IAO_0000115>An aersolised mass of dust, smoke, or other dry particulates which scatters visible light thus obsscuring  visibility through an atmosphere.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_01001458 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01001458">
+        <rdfs:label xml:lang="en">mist</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01001088"/>
+        <obo:IAO_0000115>A visible mass of water droplets or ice crystals suspended in the air at or near a planetary surface, formed when humid air cools rapidly.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IDO_0000417 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IDO_0000417">
+        <rdfs:label xml:lang="en">infectious agent transporter role</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
+        <obo:IAO_0000115 xml:lang="en">A role borne by a material entity in virtue of the fact that an infectious agent is located in or on the entity and the entity has the capability to transfer (either actively or passively) the infectious agent from one location to another. </obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IDO_0000421 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IDO_0000421">
+        <rdfs:label xml:lang="en">infectious agent vehicle role</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IDO_0000417"/>
+        <obo:IAO_0000115 xml:lang="en">An infectious agent transporter role borne by an entity in virtue of the fact that the entity is not a complete organism.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IDO_0000422 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IDO_0000422">
+        <rdfs:label xml:lang="en">biological vehicle of infectious agent role</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IDO_0000421"/>
+        <obo:IAO_0000115 xml:lang="en">An infectious agent vehicle role borne by an entity in virtue of the fact that the entity is living or contains living cells other than those that have the infectious disposition.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IDO_0000423 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IDO_0000423">
+        <rdfs:label xml:lang="en">fomite role</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IDO_0000421"/>
+        <obo:IAO_0000115 xml:lang="en">An infectious agent vehicle role borne by an entity in virtue of the fact that the entity is not alive.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
     </owl:Class>
     
 
@@ -362,6 +609,17 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IDO_0000543 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IDO_0000543">
+        <rdfs:label xml:lang="en">vehicle of infectious agent</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <obo:IAO_0000115 xml:lang="en">A material entity bearing an infectious agent vehicle role.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IDO_0000569 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IDO_0000569">
@@ -395,6 +653,24 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_11137 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11137">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus 229E</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1335626 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1335626">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Middle East respiratory syndrome-related coronavirus</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_2697049 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2697049">
@@ -402,6 +678,210 @@
         <rdfs:label>SARS-CoV-2</rdfs:label>
         <obo:IAO_0000118>Wuhan coronavirus</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">Wuhan seafood market pneumonia virus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_277944 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_277944">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NL63</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_290028 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_290028">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus HKU1</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_308726 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308726">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus type 5</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_31631 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31631">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus OC43</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384335 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384335">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384336 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384336">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/1055/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384337 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384337">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0003/05</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384338 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384338">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0749/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384339 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384339">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0848/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384340 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384340">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/1917/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384341 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384341">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0835/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384342 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384342">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0341/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384343 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384343">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0053/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384344 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384344">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0398/05</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384345 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384345">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0023/05</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384346 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384346">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0193/05</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384347 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384347">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/2708/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384348 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384348">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0733/05</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384349 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384349">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0643/05</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_384350 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_384350">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coronavirus NO/0867/04</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_384335"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_694009 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_694009">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe acute respiratory syndrome-related coronavirus</rdfs:label>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
     </owl:Class>
     
@@ -776,6 +1256,9 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arachnid borne transmission is an arthropod vector-borne transmission process during which the pathogen is indirectly transferred from a reservoir, source or host via an intermediary arthropod vector such as a tick to another host.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/trans.owl"/>
     </owl:Class>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </rdf:Description>
 </rdf:RDF>
 
 

--- a/src/ontology/imports/general_ontofox.owl
+++ b/src/ontology/imports/general_ontofox.owl
@@ -18,12 +18,15 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
         <rdfs:label>alternative term</rdfs:label>
         <rdfs:label xml:lang="en">alternative term</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)</obo:IAO_0000115>
     </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
+    </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">textual definition</rdfs:label>
@@ -35,9 +38,6 @@
         <obo:IAO_0000115>A property representing the English language definitions of what NCI means by the concept. They may also include information about the definition&#39;s source and attribution in a form that can easily be interpreted by software.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official OBI definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
-        <rdfs:label xml:lang="en">imported from</rdfs:label>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
         <rdfs:label>label</rdfs:label>
@@ -649,6 +649,15 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IDO_0000537"/>
         <obo:IAO_0000115 xml:lang="en">An organism who is host to an infectious agent and has symptoms of the infectious disease associated with the infectious agent</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_11118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11118">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coronaviridae</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cido.owl"/>
     </owl:Class>
     
 

--- a/src/ontology/imports/general_ontofox.txt
+++ b/src/ontology/imports/general_ontofox.txt
@@ -131,27 +131,6 @@ http://www.geneontology.org/formats/oboInOwl#hasSynonym
 
 
 [Source ontology]
-CIDO
-
-[Low level source term URIs]
-http://purl.obolibrary.org/obo/NCBITaxon_2697049 #severe acute respiratory syndrome coronavirus 2
-
-[Top level source term URIs and target direct superclass URIs]
-
-
-[Source term retrieval setting]
-includeNoIntermediates
-
-[Source annotation URIs]
-http://www.w3.org/2000/01/rdf-schema#label
-http://purl.obolibrary.org/obo/IAO_0000115 #iao:definition
-http://purl.obolibrary.org/obo/IAO_0000118 #iao:alternative term
-http://www.geneontology.org/formats/oboInOwl#hasSynonym
-
-[Source annotation URIs to be excluded]
-
-
-[Source ontology]
 NCIT
 
 [Low level source term URIs]
@@ -171,26 +150,6 @@ http://www.geneontology.org/formats/oboInOwl#hasSynonym
 
 [Source annotation URIs to be excluded]
 
-
-[Source ontology]
-OGMS
-
-[Low level source term URIs]
-http://purl.obolibrary.org/obo/OGMS_0000114 #immunotherapy procedure
-
-[Top level source term URIs and target direct superclass URIs]
-http://purl.obolibrary.org/obo/BFO_0000001
-
-[Source term retrieval setting]
-includeAllIntermediates
-
-[Source annotation URIs]
-http://www.w3.org/2000/01/rdf-schema#label
-http://purl.obolibrary.org/obo/IAO_0000115 #iao:definition
-http://purl.obolibrary.org/obo/IAO_0000118 #iao:alternative term
-http://www.geneontology.org/formats/oboInOwl#hasSynonym
-
-[Source annotation URIs to be excluded]
 
 
 [Source ontology]
@@ -236,3 +195,97 @@ http://www.geneontology.org/formats/oboInOwl#hasSynonym
 [Source annotation URIs to be excluded]
 
 
+[Source ontology]
+IDO
+
+[Low level source term URIs]
+http://purl.obolibrary.org/obo/IDO_0000543 #vehicle of infectious agent
+http://purl.obolibrary.org/obo/IDO_0000421 #infectious agent vehicle role
+includeAllChildren
+
+[Top level source term URIs and target direct superclass URIs]
+http://purl.obolibrary.org/obo/BFO_0000001
+
+[Source term retrieval setting]
+includeAllIntermediates
+
+[Source annotation URIs]
+http://www.w3.org/2000/01/rdf-schema#label
+http://purl.obolibrary.org/obo/IAO_0000115 #iao:definition
+http://purl.obolibrary.org/obo/IAO_0000118 #iao:alternative term
+http://www.geneontology.org/formats/oboInOwl#hasSynonym
+
+[Source annotation URIs to be excluded]
+
+
+
+
+[Source ontology]
+CIDO
+
+[Low level source term URIs]
+http://purl.obolibrary.org/obo/NCBITaxon_11137 #Human coronavirus 229E
+http://purl.obolibrary.org/obo/NCBITaxon_31631 #Human coronavirus OC43
+http://purl.obolibrary.org/obo/NCBITaxon_290028 #Human coronavirus HKU1
+http://purl.obolibrary.org/obo/NCBITaxon_277944 #Human coronavirus NL63
+http://purl.obolibrary.org/obo/NCBITaxon_694009 #Severe acute respiratory syndrome-related coronavirus
+http://purl.obolibrary.org/obo/NCBITaxon_1335626 #Middle East respiratory syndrome-related coronavirus
+http://purl.obolibrary.org/obo/NCBITaxon_2697049 #severe acute respiratory syndrome coronavirus 2
+http://purl.obolibrary.org/obo/NCBITaxon_308726 #Human coronavirus type 5
+http://purl.obolibrary.org/obo/NCBITaxon_384335 #Human coronavirus NO
+includeAllChildren
+
+[Top level source term URIs and target direct superclass URIs]
+
+[Source term retrieval setting]
+includeNoIntermediates
+
+[Source annotation URIs]
+http://www.w3.org/2000/01/rdf-schema#label
+http://purl.obolibrary.org/obo/IAO_0000115 #iao:definition
+http://purl.obolibrary.org/obo/IAO_0000118 #iao:alternative term
+http://www.geneontology.org/formats/oboInOwl#hasSynonym
+
+[Source annotation URIs to be excluded]
+
+
+[Source ontology]
+ENVO
+
+[Low level source term URIs]
+http://purl.obolibrary.org/obo/ENVO_01000831 #droplet
+http://purl.obolibrary.org/obo/ENVO_00002008 #dust
+http://purl.obolibrary.org/obo/ENVO_00010505 #aerosol
+includeAllChildren
+
+[Top level source term URIs and target direct superclass URIs]
+
+[Source term retrieval setting]
+includeNoIntermediates
+
+[Source annotation URIs]
+http://www.w3.org/2000/01/rdf-schema#label
+http://purl.obolibrary.org/obo/IAO_0000115 #iao:definition
+http://purl.obolibrary.org/obo/IAO_0000118 #iao:alternative term
+http://www.geneontology.org/formats/oboInOwl#hasSynonym
+
+
+[Source ontology]
+ENVO
+
+[Low level source term URIs]
+http://purl.obolibrary.org/obo/ENVO_00010483 #environmental material (parent of droplet, dust, aerosol)
+
+[Top level source term URIs and target direct superclass URIs]
+
+[Source term retrieval setting]
+includeNoIntermediates
+
+[Source annotation URIs]
+http://www.w3.org/2000/01/rdf-schema#label
+http://purl.obolibrary.org/obo/IAO_0000115 #iao:definition
+http://purl.obolibrary.org/obo/IAO_0000118 #iao:alternative term
+http://www.geneontology.org/formats/oboInOwl#hasSynonym
+
+
+[Source annotation URIs to be excluded]

--- a/src/ontology/imports/general_ontofox.txt
+++ b/src/ontology/imports/general_ontofox.txt
@@ -289,3 +289,24 @@ http://www.geneontology.org/formats/oboInOwl#hasSynonym
 
 
 [Source annotation URIs to be excluded]
+
+
+[Source ontology]
+CIDO
+
+[Low level source term URIs]
+http://purl.obolibrary.org/obo/NCBITaxon_11118 #Coronaviridae
+
+[Top level source term URIs and target direct superclass URIs]
+
+[Source term retrieval setting]
+includeNoIntermediates
+
+[Source annotation URIs]
+http://www.w3.org/2000/01/rdf-schema#label
+http://purl.obolibrary.org/obo/IAO_0000115 #iao:definition
+http://purl.obolibrary.org/obo/IAO_0000118 #iao:alternative term
+http://www.geneontology.org/formats/oboInOwl#hasSynonym
+
+
+[Source annotation URIs to be excluded]


### PR DESCRIPTION
imported names of all 7 coronaviruses known to infect humans as well as two more unidentified human coronaviruses from CIDO as subclasses of 'Viruses' (no generic 'human coronavirus' term in OLS)

imported 'environmental material' and children:
-droplet
-aerosol
-dust
-haven't added 'surface' yet, as most surfaces may fall under 'fomite'

added invented term as a subclass of 'survival time':
-'infectious agent survival time in environment'
